### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/rubko/plugins/db.rb
+++ b/lib/rubko/plugins/db.rb
@@ -226,7 +226,7 @@ class DbPlugin < Rubko::Plugin
 				escape element
 			}.join(',') + ')'
 		when String
-			if param.encoding.name == 'ASCII-8BIT'
+			if param.encoding == Encoding::BINARY
 				"'" + handle.escape_bytea(param) + "'"
 			else
 				"'" + handle.escape_string(param) + "'"


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576